### PR TITLE
Implement the JACK API method jack_set_client_registration_callback

### DIFF
--- a/examples/watch_for_clients.js
+++ b/examples/watch_for_clients.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * Noize generator
+ *
+ * @author Viacheslav Lotsmanov
+ */
+
+var jackConnector = require('../index.js');
+var jackClientName = 'JACK connector - client registration watcher';
+
+console.log('Opening JACK client...');
+jackConnector.openClientSync(jackClientName);
+
+function clientRegistrationCallback(name, registered) {
+    console.log('client='+name+' '+(registered? 'registered':'unregistered'));
+}
+
+console.log('Registering client-registration callback...');
+jackConnector.registerClientRegistrationCallback(clientRegistrationCallback);
+
+console.log('Activating JACK client...');
+jackConnector.activateSync();
+
+(function mainLoop() {
+	console.log('Main loop is started.');
+	setTimeout(mainLoop, 1000000000);
+})();
+
+process.on('SIGTERM', function () {
+	console.log('Deactivating JACK client...');
+	jackConnector.deactivateSync();
+	console.log('Closing JACK client...');
+	jackConnector.closeClient(function (err) {
+		if (err) {
+			console.error(err);
+			process.exit(1);
+			return;
+		}
+
+		console.log('Exiting...');
+		process.exit(0);
+	});
+});


### PR DESCRIPTION
The JACK API method jack_set_client_registration_callback is used
by a client to monitor connections and disconnections of other clients.

In turn, we will call a user supplied JS callback function with the
client name, and a boolean (connected).

Within the JACK callback context it is unsafe to access V8 internals,
so uv_async_send is used to notify a "safe" context where the callback
is actually invoked. libuv may coalesce calls to the uv_async_cb so
a linked list of information is maintained.
